### PR TITLE
pod.yaml remove linux capabilities

### DIFF
--- a/pod.yaml
+++ b/pod.yaml
@@ -41,6 +41,11 @@ spec:
       securityContext:
         allowPrivilegeEscalation: false # prevent sudo, etc.
         privileged: false               # prevent acting like host root
+        capabilities:                   # linux capabilities 
+          drop:                         # remove all capabilities
+            - ALL
+          # add:                        # add only those capabilities that is needed
+          #  - NET_ADMIN
   
   terminationGracePeriodSeconds: 600 # default is 30, but you may need more time to gracefully shutdown (HTTP long polling, user uploads, etc)
 


### PR DESCRIPTION
Hi @BretFisher !

What do you think about removing all linux capabilities by default?
Got the idea from here: https://snyk.io/blog/kubernetes-securitycontext-linux-capabilities/
